### PR TITLE
Adding the Jakarta EE & IoT contact us Button and Icon on the page #349

### DIFF
--- a/layouts/membership/section.html
+++ b/layouts/membership/section.html
@@ -1,4 +1,7 @@
 {{ define "main" }}
+  <h2 id="contact-us">Contact us about membership</h2>
+  <p>Contact us about your organization joining the Jakarta EE Working Group.</p>
+  <p class="margin-top-20"><a class="btn btn-lg btn-secondary" href="https://accounts.eclipse.org/contact/membership/jakarta-ee">Contact us about membership</a></p>
   <h2 id="out">Join Us</h2>
   <p>Working together, the world’s Java ecosystem leaders, including Fujitsu, IBM, Microsoft, Oracle, Red Hat, and Tomitribe, are advancing Java EE and Jakarta EE to support moving mission-critical applications and workloads to the cloud.</p> 
   <p>Joining the Jakarta EE Working Group demonstrates your commitment not only to the evolution and sustainability of Jakarta EE, but also to ensuring the growth and development of a well-governed, vendor-neutral open source ecosystem which benefits all.</p>


### PR DESCRIPTION
Added button+copy content under the main header of membership page about
contacting Eclipse Fdn for joining Jakarta EE

Change-Id: I99018d0a9975afedc30920331085ca3ac4922943
Signed-off-by: Martin Lowe <martin.lowe@eclipse-foundation.org>