### PR TITLE
Adding the Jakarta EE & IoT contact us Button and Icon on the page #349

### DIFF
--- a/content/membership/_index.md
+++ b/content/membership/_index.md
@@ -4,5 +4,5 @@ headline: "Shape the Future of Jakarta EE"
 date: 2018-04-05T16:09:45-04:00
 description: "Participate in an open process to shape Jakarta EE, the future of Cloud Native Java."
 hide_page_title: "true"
-links: [[href: "/membership/members", text: "Explore Members"], [href: "#benefits", text: "Membership Benefits"], [href: "#contact", text: "Join Jakarta EE"]]
+links: [[href: "/membership/members", text: "Explore Members"], [href: "#benefits", text: "Membership Benefits"], [href: "https://accounts.eclipse.org/contact/membership/jakarta-ee", text: "Join Jakarta EE"]]
 ---


### PR DESCRIPTION
Updating jumbotron link to send users to sign up page for Jakarta EE.

Change-Id: I293279968fefd3604c99561afa19bf1f436eaf1d
Signed-off-by: Martin Lowe <martin.lowe@eclipse-foundation.org>