### PR TITLE
Update to the 1.2 revision of the JESP

### DIFF
--- a/content/about/jesp/index.md
+++ b/content/about/jesp/index.md
@@ -1,24 +1,25 @@
 ---
 title: "Jakarta EE Specification Process"
-date: 2019-04-24T16:09:45-04:00
+date: 2019-07-16T13:00:00-04:00
 ---
 
-version 1.0. Effective April 9, 2019
+Version 1.2. Effective July 16/2019
 
 The Jakarta EE Specification Process (JESP) is concerned with the Specification Process as it applies to Specification Projects operating under the purview of the Jakarta EE Working Group. 
 
-The Jakarta EE Specification Committee hereby adopts the [Eclipse Foundation Specification Process v1.1](https://www.eclipse.org/projects/efsp) (EFSP) as the Jakarta EE Specification Process with the following modifications:
+The Jakarta EE Specification Committee hereby adopts the https://www.eclipse.org/projects/efsp?version=1.2[Eclipse Foundation Specification Process v1.2] (EFSP) as the Jakarta EE Specification Process with the following modifications:
 
 * Any modification to or revision of this Jakarta EE Specification Process, including the adoption of a new version of the EFSP, must be approved by a Super-majority of the Specification Committee, including a Super-majority of the Strategic Members of the Jakarta EE Working Group, in addition to any other ballot requirements set forth in the EFSP.
-* All specification committee approval ballot periods will have the minimum duration as outlined below
+* All specification committee approval ballot periods will have the minimum duration as outlined below (notwithstanding the exception process defined by the EFSP, these periods may not be shortened)
   * Creation Review: 7 calendar days;
   * Plan Review:  7 calendar days;
-  * Progress Review: 30 calendar days;
-  * Release Review: 30 calendar days;
-  * Service Release: 30 calendar days; and
+  * Progress Review: 14 calendar days;
+  * Release Review: 14 calendar days;
+  * Service Release Review: 14 calendar days; and
   * JESP Update: 7 calendar days.
+* A ballot will be declared invalid and concluded immediately in the event that the Specifiation Team withdraws from the corresponding review.
 * Specification Projects must engage in at least one Progress or Release Review  per year while in active development.
 
-All development that modifies content in the javax namespace must occur within the scope of a Specification Project operating under the purview of the Jakarta EE Working Group’s Specification Committee and must implement the process as defined by the most recently adopted revision of the JESP.
+All development that modifies content in the `javax` namespace must be moved to a `jakarta` namespace. All `jakarta` namespace development must occur within the scope of a Specification Project operating under the purview of the Jakarta EE Working Group’s Specification Committee and must implement the process as defined by the most recently adopted revision of the JESP.
 
 The EFSP takes precedence in cases where this document is silent. The primacy of the EFSP notwithstanding, this document takes precedence in all matters related to Specification development undertaken by Specification Projects within the purview of the Jakarta EE Working Group.


### PR DESCRIPTION
This new revision was approved by the Jakarta EE Specification Committee
on July 15/2019, and then by the Jakarta EE Steering Committee on July
16/2019.