### PR TITLE
Adding the Jakarta EE & IoT contact us Button and Icon on the page #349

### DIFF
--- a/content/membership/_index.md
+++ b/content/membership/_index.md
@@ -4,5 +4,5 @@ headline: "Shape the Future of Jakarta EE"
 date: 2018-04-05T16:09:45-04:00
 description: "Participate in an open process to shape Jakarta EE, the future of Cloud Native Java."
 hide_page_title: "true"
-links: [[href: "/membership/members", text: "Explore Members"], [href: "#benefits", text: "Membership Benefits"], [href: "#contact", text: "Join Jakarta EE"]]
+links: [[href: "/membership/members", text: "Explore Members"], [href: "#benefits", text: "Membership Benefits"], [href: "https://accounts.eclipse.org/contact/membership/jakarta-ee", text: "Join Jakarta EE"]]
 ---

--- a/layouts/membership/section.html
+++ b/layouts/membership/section.html
@@ -1,7 +1,7 @@
 {{ define "main" }}
   <h2 id="contact-us">Contact us about membership</h2>
   <p>Contact us about your organization joining the Jakarta EE Working Group.</p>
-  <p class="margin-top-20"><a class="btn btn-lg btn-secondary" href="https://accounts.eclipse.org/contact/membership/jakarta-ee">Contact us about membership</a></p>
+  <p class="margin-top-20"><a class="btn btn-lg btn-secondary" href="https://accounts.eclipse.org/contact/membership/jakarta-ee">Contact Us About Membership</a></p>
   <h2 id="out">Join Us</h2>
   <p>Working together, the world’s Java ecosystem leaders, including Fujitsu, IBM, Microsoft, Oracle, Red Hat, and Tomitribe, are advancing Java EE and Jakarta EE to support moving mission-critical applications and workloads to the cloud.</p> 
   <p>Joining the Jakarta EE Working Group demonstrates your commitment not only to the evolution and sustainability of Jakarta EE, but also to ensuring the growth and development of a well-governed, vendor-neutral open source ecosystem which benefits all.</p>


### PR DESCRIPTION
Updating jumbotron link to send users to sign up page for Jakarta EE.

Change-Id: I293279968fefd3604c99561afa19bf1f436eaf1d
Signed-off-by: Martin Lowe <martin.lowe@eclipse-foundation.org>