### PR TITLE
Remove RCP Vision from Jakarta EE webpage #361

### DIFF
--- a/content/membership/members.md
+++ b/content/membership/members.md
@@ -35,7 +35,6 @@ layout: "single"
           <li><a href="https://www.mizuhobank.com/index.html" target="_blank"><img src="/images/members/jakarta-member_mizuho.svg" width="100" class="img-responsive"></a></li>
           <li><a href="https://pivotal.io/" target="_blank"><img src="/images/members/jakarta-member_pivotal.svg" width="100" class="img-responsive"></a></li>
           <li><a href="https://www.k-teq.com/" target="_blank"><img src="/images/members/jakarta-member_k-teq.svg" width="100" class="img-responsive"></a></li>
-          <li><a href="http://www.rcp-vision.com/" target="_blank"><img src="/images/members/jakarta-member_rcp_vision.png" width="100" class="img-responsive"></a></li>
           <li><a href="https://www.tradista.finance/" target="_blank"><img src="/images/members/jakarta-member_tradista.png" width="100" class="img-responsive"></a></li>
           <li><a href="https://webtide.com/" target="_blank"><img src="/images/members/jakarta-member_webtide.svg" width="100" class="img-responsive"></a></li>
         </ul>


### PR DESCRIPTION
Removed RCP Vision from members page.

Change-Id: Ic353efb40a1dbfd90c4bec9ef9044120b4049e82
Signed-off-by: Martin Lowe <martin.lowe@eclipse-foundation.org>