### PR TITLE
Use a comma instead of a slash in the data format

### DIFF
--- a/content/about/jesp/index.md
+++ b/content/about/jesp/index.md
@@ -3,7 +3,7 @@ title: "Jakarta EE Specification Process"
 date: 2019-07-16T13:00:00-04:00
 ---
 
-Version 1.2. Effective July 16/2019
+Version 1.2. Effective July 16, 2019
 
 The Jakarta EE Specification Process (JESP) is concerned with the Specification Process as it applies to Specification Projects operating under the purview of the Jakarta EE Working Group. 
 


### PR DESCRIPTION
There's some odd magic happening with the rendering of the date when using a slash to separate the day from the year, so I've changed it to a comma.

![image](https://user-images.githubusercontent.com/555569/61729292-e1409c00-ad44-11e9-9789-77c42e125cec.png)

Signed-off-by: Wayne Beaton <wayne.beaton@eclipse-foundation.org>