### PR TITLE
First attempt at list file for specifications.

### DIFF
--- a/layouts/specifications/list.html
+++ b/layouts/specifications/list.html
@@ -1,0 +1,19 @@
+{{ define "main" }}
+<main>
+<div>{{.Content}}</div>
+<div class="news-list">
+	<div class="news-list-col">
+		{{ range .Page.Sections.ByWeight}}
+		<div class="news-list-media">
+			<a
+				href="{{.URL}}"
+				class="media media-link">
+				<h4 class="media-heading">{{ .Title }}</h4>
+				<p class="media-text">{{ .Summary }}</p>
+			</a>
+		</div>
+		{{ end }}
+	</div>
+</div>
+</main>
+{{ end }}


### PR DESCRIPTION
We want visitors to the /specification directory to see a list containing the title and summary for each specification.

I've got a pull request against the specifications repository that adds _index.md to each of the directories under /specifications to provide the metadata that we need to show a title and summary.