### PR TITLE
Update Social Media links in jakarta.ee footer #435

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -26,6 +26,10 @@ enableRobotsTXT = true
   call_for_action_text = "Releases"
   call_for_action_url = "/release/"
   call_for_action_icon = "fa-download"
+  linkedin_url="https://www.linkedin.com/groups/13597511/"
+  youtube_url="https://www.youtube.com/user/EclipseFdn"
+  twitter_url="https://twitter.com/JakartaEE"
+  facebook_url="https://www.facebook.com/JakartaEE"
 
 [taxonomies]
   category = "categories"


### PR DESCRIPTION
Added config values for Youtube, Facebook, Twitter, and LinkedIn footer
links.

Change-Id: I0e7fd64d036ca16ea794ae7f58decea142e47756
Signed-off-by: Martin Lowe <martin.lowe@eclipse-foundation.org>