### PR TITLE
Remove Cloudbees from the Jakarta EE website #480

### DIFF
--- a/content/membership/members.md
+++ b/content/membership/members.md
@@ -25,7 +25,6 @@ layout: "single"
           <span>Participating Members</span>
         </h3>
         <ul class="list-inline text-center">
-          <li><a href="https://www.cloudbees.com/" target="_blank"><img src="/images/members/jakarta-member_cloudbees.png" width="100" class="img-responsive"></a></li>
           <li><a href="https://www.docdoku.com/" target="_blank"><img src="/images/members/jakarta-member_docdoku.png" width="100" class="img-responsive"></a></li>
           <li><a href="https://incquerylabs.com/" target="_blank"><img src="/images/members/jakarta-member_incquerylabs.png" width="100" class="img-responsive"></a></li>
           <li><a href="https://www.liferay.com" target="_blank"><img src="/images/members/jakarta-member_liferay.svg" width="100" class="img-responsive"></a></li>


### PR DESCRIPTION
Removed cloudbees member page reference.

Change-Id: I48eaa6e98b2736f2e2858a2229db8e7d36dad7d7
Signed-off-by: Martin Lowe <martin.lowe@eclipse-foundation.org>