### PR TITLE
Please include WildFly 18.0.0.Final as both Web Profile + Full... #508

### DIFF
--- a/data/compatible_products.yml
+++ b/data/compatible_products.yml
@@ -34,10 +34,10 @@ sets:
 
     - name: WildFly
       vendor: Red Hat
-      version: 17.0.1.Final
+      version: 18.0.0.Final
       image: '/images/compatible_products/red-hat-wildfly-logo.png'
       download: 'https://wildfly.org/downloads'
-      compatibility: 'https://github.com/jakartaee/jakarta.ee/issues/452'
+      compatibility: 'https://github.com/jakartaee/jakarta.ee/issues/508'
 
   - title: Jakarta EE 8 Web Profile Compatible Products
     items:
@@ -54,3 +54,10 @@ sets:
       image: '/images/compatible_products/ibm_open_liberty.png'
       download: 'https://openliberty.io/downloads/'
       compatibility: 'https://github.com/jakartaee/jakarta.ee/issues/439'
+
+    - name: WildFly
+      vendor: Red Hat
+      version: 18.0.0.Final
+      image: '/images/compatible_products/red-hat-wildfly-logo.png'
+      download: 'https://wildfly.org/downloads'
+      compatibility: 'https://github.com/jakartaee/jakarta.ee/issues/508'


### PR DESCRIPTION
Removed v17 WebFly from Full profile, added v18 WebFly to both profiles.

Change-Id: Ice7cc45f41db68e32ce72a504114aa5d2b01048b
Signed-off-by: Martin Lowe <martin.lowe@eclipse-foundation.org>