### PR TITLE
Added documentation links

### DIFF
--- a/content/resources/_index.md
+++ b/content/resources/_index.md
@@ -6,6 +6,12 @@ description: "Jakarta EE Resources"
 layout: "single"
 ---
 
+## Documentation{#documentation}
+
+* [Jakarta EE Tutorial](https://eclipse-ee4j.github.io/jakartaee-tutorial/)
+* [Jakarta EE First Cup](https://eclipse-ee4j.github.io/jakartaee-firstcup/)
+* [CargoTracker Example Application](https://github.com/eclipse-ee4j/cargotracker)
+
 ## Surveys{#surveys}
 
 * [2018 Developer Survey](/documents/insights/2018-jakarta-ee-developer-survey.pdf)


### PR DESCRIPTION
This is a first step towards #350. Note that the First Cup is still not Jakartized and CargoTracker is missing its original website (https://m-reza-rahman.github.io/cargo-tracker/) and its documentation (https://github.com/J3E/cargo-tracker-documentation). I thinks it's acceptable as this is a temporary link.