### PR TITLE
Add ™ on jakarta.ee website #548

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,6 +1,6 @@
 baseurl = "https://jakarta.ee/"
 DefaultContentLanguage = "en"
-title = "Jakarta EE: The New Home of Cloud Native Java"
+title = "Jakarta™ EE: The New Home of Cloud Native Java"
 theme = "eclipsefdn-hugo-solstice-theme"
 metaDataFormat = "yaml"
 googleAnalytics = "UA-910670-30"
@@ -10,7 +10,7 @@ enableRobotsTXT = true
 
 [Params]
   google_tag_manager = "GTM-5WLCZXC"
-  description = "Jakarta Enterprise Edition (EE) is the future of cloud native Java. Jakarta EE open source software drives cloud native innovation, modernizes enterprise applications and protects investments in Java EE."
+  description = "Jakarta™ Enterprise Edition (EE) is the future of cloud native Java. Jakarta™ EE open source software drives cloud native innovation, modernizes enterprise applications and protects investments in Java EE."
   subtitle = "The New Home of Cloud Native Java"
   seo_title_suffix = " | The Eclipse Foundation"
   keywords = ["Jakarta EE software", "Java EE", "cloud", "microservices", "enterprise", "open source", "innovation"]
@@ -23,7 +23,7 @@ enableRobotsTXT = true
   header_wrapper_class = "header-default-bg-img"
   js = "js/solstice.js"
   show_events = true
-  call_for_action_text = "Releases"
+  call_for_action_text = "Download"
   call_for_action_url = "/release/"
   call_for_action_icon = "fa-download"
   linkedin_url="https://www.linkedin.com/groups/13597511/"

--- a/content/_index.md
+++ b/content/_index.md
@@ -1,11 +1,11 @@
 ---
 title: "Home"
-seo_title: "Jakarta EE Software | Cloud Native"
-headline: "Jakarta EE"
+seo_title: "Jakarta™ EE Software | Cloud Native"
+headline: "Jakarta™ EE"
 subtitle: "Open Source Cloud Native Java"
-description: "Jakarta Enterprise Edition (EE) is the future of cloud native Java. Jakarta EE open source software drives cloud native innovation, modernizes enterprise applications and protects investments in Java EE."
-tagline: "Powered by participation, Jakarta EE is focused on enabling community-driven collaboration and open innovation for the cloud."
-links: [[href: "about/", text: "About Jakarta EE"], [href: "https://projects.eclipse.org/projects/ee4j", text: "Projects"], [href: "specifications/", text: "Specifications"], [href: "membership/", text: "Join Us"]]
+description: "Jakarta™ Enterprise Edition (EE) is the future of cloud native Java. Jakarta™ EE open source software drives cloud native innovation, modernizes enterprise applications and protects investments in Java EE."
+tagline: "Powered by participation, Jakarta™ EE is focused on enabling community-driven collaboration and open innovation for the cloud."
+links: [[href: "about/", text: "About Jakarta™ EE"], [href: "https://projects.eclipse.org/projects/ee4j", text: "Projects"], [href: "specifications/", text: "Specifications"], [href: "membership/", text: "Join Us"]]
 date: 2018-04-05T15:50:25-04:00
 hide_page_title: true
 hide_sidebar: true

--- a/content/about/_index.md
+++ b/content/about/_index.md
@@ -1,8 +1,8 @@
 ---
 title: "About"
-headline: "Jakarta EE Working Group"
+headline: "Jakarta™ EE Working Group"
 date: 2018-04-05T16:09:45-04:00
-description: "Explore and learn about us and the future direction of Jakarta EE."
+description: "Explore and learn about us and the future direction of Jakarta™ EE."
 hide_page_title: "true"
 layout: "single"
 ---

--- a/content/about/jesp/index.md
+++ b/content/about/jesp/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Jakarta EE Specification Process"
+title: "Jakarta™ EE Specification Process"
 date: 2019-07-16T13:00:00-04:00
 ---
 

--- a/content/compatibility/_index.md
+++ b/content/compatibility/_index.md
@@ -1,8 +1,8 @@
 ---
-title: "Compatible Products"
-headline: "Compatible Products"
+title: "Jakarta™ EE Compatible Products"
+headline: "Jakarta™ EE Compatible Products"
 date: 2019-04-2T11:10:38-04:00
-description: "Compatible Implementations of Jakarta EE"
+description: "Compatible Implementations of Jakarta™ EE"
 hide_sidebar: true
 draft: false
 links: [[href: "get_listed", text: "Get Listed"]]

--- a/content/compatibility/get_listed/_index.md
+++ b/content/compatibility/get_listed/_index.md
@@ -2,7 +2,7 @@
 title: "Get Listed"
 headline: "Get Listed"
 date: 2019-06-5T11:10:38-04:00
-description: "Compatible Implementations of Jakarta EE"
+description: "Compatible Implementations of Jakarta™ EE"
 hide_sidebar: true
 hide_page_title: true
 draft: false

--- a/content/connect/index.md
+++ b/content/connect/index.md
@@ -2,7 +2,7 @@
 title: "Stay Connected"
 headline: "Stay Connected" 
 date: 2018-04-05T16:10:38-04:00
-description: "Keep up to date with Jakarta EE working group updates, community news and announcement."
+description: "Keep up to date with Jakarta™ EE working group updates, community news and announcement."
 hide_sidebar: "true"
 ---
 <h2 class="text-center heading-line"><span>Mailing Lists</span></h2>

--- a/content/legal/trademark_guidelines/index.md
+++ b/content/legal/trademark_guidelines/index.md
@@ -1,7 +1,7 @@
 ---
-title: "Jakarta EE Trademark Guidelines"
+title: "Jakarta™ EE Trademark Guidelines"
 date: 2018-04-05T16:10:38-04:00
-description: "Supplement to the Eclipse Foundation Guidelines for Eclipse Logos & Trademarks Policy for Jakarta EE Marks"
+description: "Supplement to the Eclipse Foundation Guidelines for Eclipse Logos & Trademarks Policy for Jakarta™ EE Marks"
 hide_sidebar: "false"
 ---
 <p><em>Supplement to the Eclipse Foundation Guidelines for Eclipse Logos & Trademarks Policy for Jakarta EE Marks</em></p>

--- a/content/meeting_minutes/_index.md
+++ b/content/meeting_minutes/_index.md
@@ -1,5 +1,5 @@
 ---
-title: "Jakarta EE Working Group Committees Meeting Minutes"
+title: "Jakarta™ EE Working Group Committees Meeting Minutes"
 date: 2018-06-22T13:30:00-00:00
 description: "Meeting Minutes"
 ---

--- a/content/membership/_index.md
+++ b/content/membership/_index.md
@@ -1,8 +1,8 @@
 ---
 title: "Membership"
-headline: "Shape the Future of Jakarta EE"
+headline: "Shape the Future of Jakarta™ EE"
 date: 2018-04-05T16:09:45-04:00
-description: "Participate in an open process to shape Jakarta EE, the future of Cloud Native Java."
+description: "Participate in an open process to shape Jakarta™ EE, the future of Cloud Native Java."
 hide_page_title: "true"
-links: [[href: "/membership/members", text: "Explore Members"], [href: "#benefits", text: "Membership Benefits"], [href: "https://accounts.eclipse.org/contact/membership/jakarta-ee", text: "Join Jakarta EE"]]
+links: [[href: "/membership/members", text: "Explore Members"], [href: "#benefits", text: "Membership Benefits"], [href: "https://accounts.eclipse.org/contact/membership/jakarta-ee", text: "Join Jakarta™ EE"]]
 ---

--- a/content/newsletter/index.md
+++ b/content/newsletter/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Jakarta EE Newsletter Archives"
+title: "Jakarta™ EE Newsletter Archives"
 date: 2018-06-04T10:00:58-04:00
 description: "Keep up to date with Jakarta EE working group updates, community news and announcement."
 ---

--- a/content/release/_index.md
+++ b/content/release/_index.md
@@ -1,11 +1,11 @@
 ---
-title: "Jakarta EE 8 Delivers"
+title: "Jakarta™ EE 8 Delivers"
 date: 2018-04-05T16:10:38-04:00
-description: "Keep up to date with Jakarta EE working group updates, community news and announcement."
+description: "Keep up to date with Jakarta™ EE working group updates, community news and announcement."
 hide_sidebar: true
-seo_title: "Jakarta EE Software | Cloud Native"
-headline: "Jakarta&nbsp;EE"
-links: [[href: "/compatibility/", text: "Compatible Products"], [href: "/specifications/", text: "Specifications"]]
+seo_title: "Jakarta™ EE Software | Cloud Native"
+headline: "Jakarta™&nbsp;EE"
+links: [[href: "/compatibility/", text: "Download Compatible Products"], [href: "/specifications/", text: "Specifications"]]
 hide_page_title: true
 header_wrapper_class: "header-download"
 ---

--- a/content/resources/_index.md
+++ b/content/resources/_index.md
@@ -2,14 +2,14 @@
 title: "Resources"
 headline: "Resources" 
 date: 2019-02-27T16:10:38-04:00
-description: "Jakarta EE Resources"
+description: "Jakarta™ EE Resources"
 layout: "single"
 ---
 
 ## Documentation{#documentation}
 
-* [Jakarta EE Tutorial](https://eclipse-ee4j.github.io/jakartaee-tutorial/)
-* [Jakarta EE First Cup](https://eclipse-ee4j.github.io/jakartaee-firstcup/)
+* [Jakarta™ EE Tutorial](https://eclipse-ee4j.github.io/jakartaee-tutorial/)
+* [Jakarta™ EE First Cup](https://eclipse-ee4j.github.io/jakartaee-firstcup/)
 * [CargoTracker Example Application](https://github.com/eclipse-ee4j/cargotracker)
 
 ## Surveys{#surveys}
@@ -23,13 +23,13 @@ layout: "single"
 
 ## Infographics{#infographics}
 
-* [2018 Jakarta EE survey infographic](https://jakarta.ee/documents/insights/2018-jakarta-ee-survey-infographic.pdf)
+* [2018 Jakarta™ EE survey infographic](https://jakarta.ee/documents/insights/2018-jakarta-ee-survey-infographic.pdf)
 
 <hr>
 
 ## Presentations{#presentations}  
 
-* [Jakarta EE presentations](https://www.slideshare.net/Jakarta_EE)
+* [Jakarta™ EE presentations](https://www.slideshare.net/Jakarta_EE)
 
 <hr>
 

--- a/data/compatible_products.yml
+++ b/data/compatible_products.yml
@@ -9,7 +9,7 @@
 #      download: 'https://www.eclipse.org/downloads/download.php?file=/glassfish/glassfish-5.1.0.zip'
 
 sets:
-  - title: Jakarta EE 8 Full Platform Compatible Products
+  - title: Jakarta™ EE 8 Full Platform Compatible Products
     items:
     - name: Payara Server 
       vendor: Payara Services Limited
@@ -39,7 +39,7 @@ sets:
       download: 'https://wildfly.org/downloads'
       compatibility: 'https://github.com/jakartaee/jakarta.ee/issues/508'
 
-  - title: Jakarta EE 8 Web Profile Compatible Products
+  - title: Jakarta™ EE 8 Web Profile Compatible Products
     items:
     - name: Eclipse Glassfish
       vendor: Eclipse Foundation

--- a/data/featuredstory.yml
+++ b/data/featuredstory.yml
@@ -6,7 +6,7 @@ defaultRight: |
         </div>
 items:
   -
-    title: Jakarta EE 8 is here!
+    title: Jakarta™ EE 8 is here!
     content: Check out all the info and updates about the Jakarta EE 8 release!
     link: <a class="btn btn-primary btn-lg" href="https://jakarta.ee/release/">Learn More</a>
     bgImgSrc: /images/jakarta-ee-banner.jpg


### PR DESCRIPTION
Updated Jumbotron, titles, descriptions, and some data objects to have
TM marks for Jakarta references.

Signed-off-by: Martin Lowe <martin.lowe@eclipse-foundation.org>