### PR TITLE
Updated Marketing Committee alternate for Oracle

### DIFF
--- a/content/about/_index.md
+++ b/content/about/_index.md
@@ -65,7 +65,7 @@ Jakarta EE represents the best way to drive cloud-native, mission critical appli
         <ul>
 			<li>Michael DeNicola - Fujitsu, Kenji Kazumura - alternate</li>
 			<li>Dan Bandera - IBM, Neil Patterson - alternate</li>
-			<li>Ed Bratt - Oracle, David Delabassee - alternate</li>
+			<li>Ed Bratt - Oracle, Melissa Jacobus - alternate</li>
 			<li>Dominika Tasarz - Payara, Jadon Orglepp - alternate</li>
 			<li>Cesar Saavedra - Red Hat, Paul Hinz - alternate</li>
 			<li>David Blevins - Tomitribe, Jonathan Gallimore - alternate</li>


### PR DESCRIPTION
Replaced David Delabassee with Melissa Jacobus as Marketing Committee alternate.

Signed-off-by: Ed Bratt <ed.bratt@oracle.com>