### PR TITLE
Fix typo in name of Specification Committee.

### DIFF
--- a/content/committees/specification/_index.md
+++ b/content/committees/specification/_index.md
@@ -1,6 +1,6 @@
 ---
-title: "Specifications Committee"
-date: 2020-01-05T15:50:25-04:00
+title: "Specification Committee"
+date: 2020-02-19T15:00:25-08:00
 ---
 
 The Specification Committee is responsible for implementing the ​[Jakarta EE Specification Process (JESP)](/about/jesp/) ​for all Specification Projects under the purview of the Jakarta EE Working Group. This committee ensures that JESP is followed as intended, votes to approve creation reviews, progress reviews and release reviews submitted by Specification projects.


### PR DESCRIPTION
It's not plural.