### PR TITLE
Update batch XSDs to version 2.0

### DIFF
--- a/xml/ns/jakartaee/batchXML_2_0.xsd
+++ b/xml/ns/jakartaee/batchXML_2_0.xsd
@@ -20,7 +20,7 @@
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
     elementFormDefault="qualified"
     targetNamespace="https://jakarta.ee/xml/ns/jakartaee"
-    xmlns:jbatch="https://jakarta.ee/xml/ns/jakartaee" version="1.0">
+    xmlns:jbatch="https://jakarta.ee/xml/ns/jakartaee" version="2.0">
     
     <xs:element name="batch-artifacts"
         type="jbatch:BatchArtifacts" />

--- a/xml/ns/jakartaee/jobXML_2_0.xsd
+++ b/xml/ns/jakartaee/jobXML_2_0.xsd
@@ -20,7 +20,7 @@
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
     elementFormDefault="qualified"
     targetNamespace="https://jakarta.ee/xml/ns/jakartaee"
-    xmlns:jsl="https://jakarta.ee/xml/ns/jakartaee" version="1.0">
+    xmlns:jsl="https://jakarta.ee/xml/ns/jakartaee" version="2.0">
     <xs:annotation>
         <xs:documentation>
             Job Specification Language (JSL) specifies a job,
@@ -28,6 +28,8 @@
             JSL also can be referred to as "Job XML".
         </xs:documentation>
     </xs:annotation>
+
+    <xs:include schemaLocation="jakartaee_9.xsd"/>
 
     <xs:simpleType name="artifactRef">
         <xs:annotation>
@@ -78,7 +80,7 @@
                 <xs:element name="step" type="jsl:Step" />
             </xs:choice>
         </xs:sequence>
-        <xs:attribute name="version" use="required" type="xs:string" fixed="1.0" />
+        <xs:attribute name="version" use="required" type="jsl:dewey-versionType" fixed="2.0" />
         <xs:attribute name="id" use="required" type="xs:ID" />
         <xs:attribute name="restartable" use="optional" type="xs:string" />
     </xs:complexType>


### PR DESCRIPTION
Signed-off-by: Scott Kurz <skurz@us.ibm.com>

Following Jakarta EE 9 convention , have the "version" attribute for the top-level element ("job") match the spec version and file name... so bump up from 1.0 to 2.0.

The earlier PR #707 converted the target NS of the schema elements but it left the version as 1.0.