### PR TITLE
Update batch XSDs to version 2.0

### DIFF
--- a/static/xml/ns/jakartaee/batchXML_2_0.xsd
+++ b/static/xml/ns/jakartaee/batchXML_2_0.xsd
@@ -20,7 +20,7 @@
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
     elementFormDefault="qualified"
     targetNamespace="https://jakarta.ee/xml/ns/jakartaee"
-    xmlns:jbatch="https://jakarta.ee/xml/ns/jakartaee" version="1.0">
+    xmlns:jbatch="https://jakarta.ee/xml/ns/jakartaee" version="2.0">
     
     <xs:element name="batch-artifacts"
         type="jbatch:BatchArtifacts" />

--- a/static/xml/ns/jakartaee/jobXML_2_0.xsd
+++ b/static/xml/ns/jakartaee/jobXML_2_0.xsd
@@ -20,7 +20,7 @@
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
     elementFormDefault="qualified"
     targetNamespace="https://jakarta.ee/xml/ns/jakartaee"
-    xmlns:jsl="https://jakarta.ee/xml/ns/jakartaee" version="1.0">
+    xmlns:jsl="https://jakarta.ee/xml/ns/jakartaee" version="2.0">
     <xs:annotation>
         <xs:documentation>
             Job Specification Language (JSL) specifies a job,
@@ -28,6 +28,26 @@
             JSL also can be referred to as "Job XML".
         </xs:documentation>
     </xs:annotation>
+
+    <xs:simpleType name="batchVersionType">
+      <xs:annotation>
+        <xs:documentation>
+
+            Defines a decimal type used for versioning documents
+            defined via this scheam.  Intended to be identical
+            to the "dewey-versionType" dewey decimal restriction
+            type defined in
+            https://jakarta.ee/xml/ns/jakartaee/jakartaee_9.xsd
+            but without the need to include that schema definition
+            file.
+
+        </xs:documentation>
+      </xs:annotation>
+
+      <xs:restriction base="xsd:token">
+        <xs:pattern value="\.?[0-9]+(\.[0-9]+)*"/>
+      </xs:restriction>
+    </xs:simpleType>
 
     <xs:simpleType name="artifactRef">
         <xs:annotation>
@@ -78,7 +98,7 @@
                 <xs:element name="step" type="jsl:Step" />
             </xs:choice>
         </xs:sequence>
-        <xs:attribute name="version" use="required" type="xs:string" fixed="1.0" />
+        <xs:attribute name="version" use="required" type="jsl:batchVersionType" fixed="2.0" />
         <xs:attribute name="id" use="required" type="xs:ID" />
         <xs:attribute name="restartable" use="optional" type="xs:string" />
     </xs:complexType>


### PR DESCRIPTION
Signed-off-by: Scott Kurz <skurz@us.ibm.com>

Following Jakarta EE 9 convention , have the "version" attribute for the top-level element ("job") match the spec version and file name... so bump up from 1.0 to 2.0.

The earlier PR #707 converted the target NS of the schema elements but it left the version as 1.0.

The matching PR in 'batch-api': eclipse-ee4j/batch-api#103 has been reviewed (unfortunately we have the files duplicated across the two projects, but changes should be rare).

One slightly less-elegant component of this fix is to define our own version type, as mentioned in the comment.  This avoids including the common Jakarta schema file which doesn't seem worth it for such a simple type definition.   Tried to avoid any namespace collision with the 'batchVersionType' name.

---

(We can ignore the similar PR https://github.com/jakartaee/jakarta.ee/pull/840, which got messed up by me using the wrong base branch.)