### PR TITLE
Revert "Open Liberty 20.0.0.3 as a Compatible Software Product"

### DIFF
--- a/data/compatible_products.yml
+++ b/data/compatible_products.yml
@@ -27,10 +27,10 @@ sets:
 
     - name: Open Liberty
       vendor: IBM Corporation
-      version: 20.0.0.3
+      version: 19.0.0.6
       image: '/images/compatible_products/ibm_open_liberty.png'
       download: 'https://openliberty.io/downloads/'
-      compatibility: 'https://github.com/jakartaee/jakarta.ee/issues/855'
+      compatibility: 'https://github.com/jakartaee/jakarta.ee/issues/439'
 
     - name: WildFly
       vendor: Red Hat
@@ -78,10 +78,10 @@ sets:
 
     - name: Open Liberty
       vendor: IBM Corporation
-      version: 20.0.0.3
+      version: 19.0.0.6
       image: '/images/compatible_products/ibm_open_liberty.png'
       download: 'https://openliberty.io/downloads/'
-      compatibility: 'https://github.com/jakartaee/jakarta.ee/issues/855'
+      compatibility: 'https://github.com/jakartaee/jakarta.ee/issues/439'
 
     - name: WildFly
       vendor: Red Hat


### PR DESCRIPTION
https://github.com/jakartaee/jakarta.ee/pull/856#issuecomment-681109524

This reverts commit 0d733aa1d462d30d475c5da8ada1804411897cab.