### PR TITLE
add 2 members in commitee/specifications page

### DIFF
--- a/content/committees/specification/_index.md
+++ b/content/committees/specification/_index.md
@@ -20,7 +20,5 @@ The Specification Committee is responsible for implementing the ​[Jakarta EE S
 * Werner Keil - Elected Committer Member Representative
 * Scott (Congquan) Wang - Primeton - Elected Enterprise Representative
 * Paul Buck - Eclipse Foundation (serves as chair, but is not a voting committee member)
-* Dmitry Kornilov - Oracle
-* Martijn Verburg - Participant Member
 
 {{< meeting-minutes-single "specification_committee" >}}

--- a/content/committees/specification/_index.md
+++ b/content/committees/specification/_index.md
@@ -11,7 +11,7 @@ The Specification Committee is responsible for implementing the ​[Jakarta EE S
 
 * Kenji Kazumura - Fujitsu
 * Dan Bandera - IBM, Kevin Sutter - alternate
-* Ed Bratt - Oracle,
+* Ed Bratt - Oracle
 * Andrew Pielage - Payara, Matt Gill - alternate
 * Scott Stark - Red Hat, Mark Little - alternate
 * David Blevins - Tomitribe, Jean-Louis Monterio - alternate
@@ -20,5 +20,7 @@ The Specification Committee is responsible for implementing the ​[Jakarta EE S
 * Werner Keil - Elected Committer Member Representative
 * Scott (Congquan) Wang - Primeton - Elected Enterprise Representative
 * Paul Buck - Eclipse Foundation (serves as chair, but is not a voting committee member)
+* Dmitry Kornilov - Oracle
+* Martijn Verburg - Participant Member
 
 {{< meeting-minutes-single "specification_committee" >}}

--- a/content/committees/specification/_index.md
+++ b/content/committees/specification/_index.md
@@ -11,12 +11,12 @@ The Specification Committee is responsible for implementing the ​[Jakarta EE S
 
 * Kenji Kazumura - Fujitsu
 * Dan Bandera - IBM, Kevin Sutter - alternate
-* Ed Bratt - Oracle
+* Ed Bratt - Oracle, Dmitry Kornilov - alternate
 * Andrew Pielage - Payara, Matt Gill - alternate
 * Scott Stark - Red Hat, Mark Little - alternate
 * David Blevins - Tomitribe, Jean-Louis Monterio - alternate
 * Ivar Grimstad - PMC Representative
-* Marcelo Ancelmo - London Java Community - Elected Participant Member Representative
+* Marcelo Ancelmo - London Java Community - Elected Participant Member Representative, Martijn Verburg - alternate
 * Werner Keil - Elected Committer Member Representative
 * Scott (Congquan) Wang - Primeton - Elected Enterprise Representative
 * Paul Buck - Eclipse Foundation (serves as chair, but is not a voting committee member)


### PR DESCRIPTION
After referring to `Contributing `in `readme`, this should be to src. 

fix #883 

Signed-off-by: Yi Liu <yi.liu@eclipse-foundation.org>