### PR TITLE
fix documentation sub menu not showing under resources

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -84,7 +84,7 @@ enableInlineShortcodes = true
 [[menu.main]]
     name = "Documentation"
     url = "/resources#documentation"
-    parent = "Documentation"
+    parent = "Resources"
     weight = 1
 
 [[menu.main]]


### PR DESCRIPTION
Fix #890 

![image](https://user-images.githubusercontent.com/39588094/93250189-7203e380-f760-11ea-8067-54244eb09060.png)

Signed-off-by: Yi Liu <yi.liu@eclipse-foundation.org>