### PR TITLE
Navigation sidebar contains broken links #927

### DIFF
--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -156,6 +156,3 @@
 
 [sidebar-specification-process]
   other = "Specification Process"
-
-[sidebar-url-prefix]
-  other = ""  

--- a/i18n/zh.toml
+++ b/i18n/zh.toml
@@ -184,9 +184,6 @@
 [sidebar-specification-process]
   other = "规范过程"
 
-[sidebar-url-prefix]
-  other = "/zh"
-
 [pages-newsletter-sign-up-to-our-newsletter]
   other = "订阅我们的简讯"
 

--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -2,23 +2,23 @@
 <aside id="main-sidebar">
   <ul id="leftnav" class="ul-left-nav fa-ul hidden-print">
     <li class="separator">
-      <a class="separator" href="{{ i18n "sidebar-url-prefix"}}/">{{ i18n "sidebar-title"}}</a>
+      <a class="separator" href="{{ absLangURL "/" }}">{{ i18n "sidebar-title"}}</a>
     </li>
     <li>
       <i class="fa fa-caret-right fa-fw"></i>
-      <a href="{{ i18n "sidebar-url-prefix"}}/about/" target="_self">{{ i18n "sidebar-about-jakartaee"}}</a>
+      <a href="{{ absLangURL "/about/" }}" target="_self">{{ i18n "sidebar-about-jakartaee"}}</a>
     </li>
     <li>
       <i class="fa fa-caret-right fa-fw"></i>
-      <a href="{{ i18n "sidebar-url-prefix"}}/about/faq/" target="_self">{{ i18n "sidebar-faqs"}}</a>
+      <a href="{{ absLangURL "/about/faq/" }}" target="_self">{{ i18n "sidebar-faqs"}}</a>
     </li>
     <li>
       <i class="fa fa-caret-right fa-fw"></i>
-      <a href="{{ i18n "sidebar-url-prefix"}}/membership/" target="_self">{{ i18n "sidebar-become-a-member"}}</a>
+      <a href="{{ absLangURL "/membership/" }}" target="_self">{{ i18n "sidebar-become-a-member"}}</a>
     </li>
     <li>
       <i class="fa fa-caret-right fa-fw"></i>
-      <a href="{{ i18n "sidebar-url-prefix"}}/connect/" target="_self">{{ i18n "sidebar-connect"}}</a>
+      <a href="{{ absLangURL "/connect/" }}" target="_self">{{ i18n "sidebar-connect"}}</a>
     </li>
     <li>
       <i class="fa fa-caret-right fa-fw"></i>
@@ -30,20 +30,20 @@
     </li>
     <li>
       <i class="fa fa-caret-right fa-fw"></i>
-      <a href="{{ i18n "sidebar-url-prefix"}}/newsletter" target="_self">{{ i18n "sidebar-newsletter-archives"}}</a>
+      <a href="{{ absLangURL "/newsletter" }}" target="_self">{{ i18n "sidebar-newsletter-archives"}}</a>
     </li>
     <li>
       <i class="fa fa-caret-right fa-fw"></i>
-      <a href="{{ i18n "sidebar-url-prefix"}}/meeting_minutes" target="_self">{{ i18n "sidebar-meeting-minutes"}}</a>
+      <a href="{{ absLangURL "/meeting_minutes" }}" target="_self">{{ i18n "sidebar-meeting-minutes"}}</a>
     </li>
     
     <li>
       <i class="fa fa-caret-right fa-fw"></i>
-      <a href="{{ i18n "sidebar-url-prefix"}}/legal/trademark_guidelines/" target="_self">{{ i18n "sidebar-trademark-guidelines"}}</a>
+      <a href="{{ absLangURL "/legal/trademark_guidelines/" }}" target="_self">{{ i18n "sidebar-trademark-guidelines"}}</a>
     </li>
     <li>
       <i class="fa fa-caret-right fa-fw"></i>
-      <a href="{{ i18n "sidebar-url-prefix"}}/about/jesp/" target="_self">{{ i18n "sidebar-specification-process"}}</a>
+      <a href="{{ absLangURL "/about/jesp/" }}" target="_self">{{ i18n "sidebar-specification-process"}}</a>
     </li>
   </ul>
 </aside>


### PR DESCRIPTION
Fix sidebar URLs to use absLangURL function rather than a broken
hardcoded prefix.

Fixes #927.

Signed-off-by: Martin Lowe <martin.lowe@eclipse-foundation.org>