### PR TITLE
Update schemas to final for 9.0

### DIFF
--- a/data/jakartaee_schemas.yml
+++ b/data/jakartaee_schemas.yml
@@ -14,17 +14,17 @@ releases:
     - schema: jakartaee_9.xsd
       namespace: jakartaee
       description: Common shareable schemas of Jakarta EE deployment descriptors
-      status: Draft
+      status: Final
 
     - schema: jakartaee_web_services_metadata_handler_3_0.xsd
       namespace: jakartaee
       description: XML Schema for the Handler chain configuration descriptor
-      status: Draft
+      status: Final
 
     - schema: batchXML_2_0.xsd
       namespace: jakartaee
       description: XML Schema for the Jakarta Batch artifacts XML file (batch.xml)
-      status: Draft
+      status: Final
 
     - schema: beans_3_0.xsd
       namespace: jakartaee
@@ -34,82 +34,82 @@ releases:
     - schema: jobXML_2_0.xsd
       namespace: jakartaee
       description: XML Schema for the Jakarta Batch Job Specification Language (JSL)
-      status: Draft
+      status: Final
 
     - schema: jsp_3_0.xsd
       namespace: jakartaee
       description: XML Schema for the JavaServer Pages deployment descriptor
-      status: Draft
+      status: Final
 
     - schema: application_9.xsd
       namespace: jakartaee
       description: XML Schema for the Application deployment descriptor
-      status: Draft
+      status: Final
 
     - schema: application-client_9.xsd
       namespace: jakartaee
       description: XML Schema for the Application client deployment descriptor
-      status: Draft
+      status: Final
 
     - schema: connector_2_0.xsd
       namespace: jakartaee
       description: XML Schema for the Connectors deployment descriptor
-      status: Draft
+      status: Final
 
     - schema: ejb-jar_4_0.xsd
       namespace: jakartaee
       description: XML Schema for the Enterprise Beans deployment descriptor
-      status: Draft
+      status: Final
 
     - schema: jakartaee_web_services_2_0.xsd
       namespace: jakartaee
       description: XML Schema for the Web Services deployment descriptor
-      status: Draft
+      status: Final
 
     - schema: jakartaee_web_services_client_2_0.xsd
       namespace: jakartaee
       description: XML Schema for the Web Services Client deployment descriptor
-      status: Draft
+      status: Final
 
     - schema: permissions_9.xsd
       namespace: jakartaee
       description: XML Schema for the application or module declared permissions
-      status: Draft
+      status: Final
 
     - schema: web-app_5_0.xsd
       namespace: jakartaee
       description: XML Schema for the Servlet deployment descriptor (web.xml)
-      status: Draft
+      status: Final
 
     - schema: web-fragment_5_0.xsd
       namespace: jakartaee
       description: XML Schema for the Servlet deployment descriptor (web-fragment.xml)
-      status: Draft
+      status: Final
 
     - schema: web-common_5_0.xsd
       namespace: jakartaee
       description: XML Schema common for the various Servlet deployment descriptors
-      status: Draft
+      status: Final
       
     - schema: web-facesconfig_3_0.xsd
       namespace: jakartaee
       description: XML Schema for the Jakarta Server Faces Application Configuration File
-      status: Draft
+      status: Final
       
     - schema: web-facelettaglibrary_3_0.xsd
       namespace: jakartaee
       description: XML Schema for the Tag Libraries in the Jakarta Server Faces Standard Facelets View Declaration Language (Facelets VDL)
-      status: Draft
+      status: Final
       
     - schema: web-partialresponse_3_0.xsd
       namespace: jakartaee
       description: XML Schema for the Jakarta Server Faces Partial Response used in JSF Ajax frameworks
-      status: Draft
+      status: Final
 
     - schema: web-jsptaglibrary_3_0.xsd
       namespace: jakartaee
       description: XML Schema for the Jakarta Server Pages Taglibrary descriptor
-      status: Draft
+      status: Final
 
 # Template: Example for creating new schema entry
 #   - schema: a_simple_example.xsd

--- a/data/jaxb_schemas.yml
+++ b/data/jaxb_schemas.yml
@@ -8,7 +8,7 @@ releases:
     - schema: bindingschema_3_0.xsd
       namespace: jaxb
       description: XML Schema for the Jakarta XML Binding binding customization descriptor
-      status: Draft
+      status: Final
 
 # Template: Example for creating new schema entry
 #   - schema: a_simple_example.xsd

--- a/data/jaxws_schemas.yml
+++ b/data/jaxws_schemas.yml
@@ -8,7 +8,7 @@ releases:
     - schema: wsdl_customizationschema_3_0.xsd
       namespace: jaxws
       description: XML Schema for the Jakarta XML Web Services WSDL customization descriptor
-      status: Draft
+      status: Final
 
 # Template: Example for creating new schema entry
 #   - schema: a_simple_example.xsd

--- a/data/persistence_schemas.yml
+++ b/data/persistence_schemas.yml
@@ -8,12 +8,12 @@ releases:
     - schema: orm_3_0.xsd
       namespace: persistence/orm
       description: XML Schema for for the persistence object/relational mapping file
-      status: Draft
+      status: Final
 
     - schema: persistence_3_0.xsd
       namespace: persistence
       description: XML Schema for the persistence configuration file
-      status: Draft
+      status: Final
 
 # Template: Example for creating new schema entry
 #   - schema: a_simple_example.xsd


### PR DESCRIPTION
Marking final for the following schemas:

- jakartaee_9
- jakartaee_web_services_metadata_handler_3_0
- batchXML_2_0
- jobXML_2_0
- jsp_3_0
- application_9
- application-client_9
- connector_2_0
- ejb-jar_4_0
- jakartaee_web_services_2_0
- jakartaee_web_services_client_2_0
- permissions_9
- web-app_5_0
- web-fragment_5_0
- web-common_5_0
- web-facesconfig_3_0
- web-facelettaglibrary_3_0
- web-partialresponse_3_0
- web-jsptaglibrary_3_0
- bindingschema_3_0
- wsdl_customizationschema_3_0
- orm_3_0
- persistence_3_0