### PR TITLE
update internal doc refs to get to the proper section at least

### DIFF
--- a/content/committees/specification/operations/index.md
+++ b/content/committees/specification/operations/index.md
@@ -248,7 +248,7 @@ Although a release review is not required, several of the following requirements
 A release review will have validated that the specification
 project has:
 
-1.  <a name="staging_artifacts">Produced</a> a final staging release via OSSRH staging repository for the api,
+1.  Produced a final staging release via OSSRH staging repository for the api,
     javadoc. 
 
     -   Javadocs should include the [Eclipse Foundation Specification
@@ -280,7 +280,7 @@ project has:
     compatibility-certification-request template, you can use this one:
     [compatibility-certification-request.md](https://github.com/jakartaee/specification-committee/blob/master/compatibility-certification-request.md)
     
-5.  <a name="create_specification_pr">Initiate</a> a Specification review request by creating
+5.  Initiate a Specification review request by creating
     [draft PRs](https://help.github.com/en/articles/about-pull-requests#draft-pull-requests)
     (also assign the `draft` label) against the [Jakarta EE Specification Committee
     specifications](https://github.com/jakartaee/specifications)
@@ -364,9 +364,9 @@ There is no formal release review required for a Specification service release (
 That is, no functionality changes or increase in IP scope are permitted in a service release.
 Although much of the content of the [Final Specification](#creating_a_final_specification) still applies, the approval process is simplified for a service release.
 
-1. The creation and staging of the various artifacts (Specification, API, and/or TCK) are still performed via the [initial steps 1 and 2 outlined above](#staging_artifacts).
+1. The creation and staging of the various artifacts (Specification, API, and/or TCK) are still performed via the [initial steps 1 and 2 outlined above](#creating_a_final_specification).
 
-2. The [creation of Specification PRs in step 5](#create_specification_pr) is also required.
+2. The [creation of Specification PRs in step 5](#creating_a_final_specification) is also required.
 
 3. The Specification Project team should then send a note to the [public Specification Committee mailing list](https://accounts.eclipse.org/mailing-list/jakarta.ee-spec) announcing that the PRs are ready for review.
 


### PR DESCRIPTION
Signed-off-by: Kevin Sutter <kwsutter@gmail.com>

The markdown rendering in Hugo didn't accomplish what I was looking for.  I was trying to create a reference for a specific step in the process, but I've tried several different variations and can't get it to work properly.  So, I'm going to revert to just mentioning the desired steps and reference the overall section on creating a final specification.  Good enough...