### PR TITLE
Link JakartaOne Livestream to livestream card on /resources

### DIFF
--- a/layouts/shortcodes/pages/resources.html
+++ b/layouts/shortcodes/pages/resources.html
@@ -80,7 +80,7 @@
         </div>
     </div>
     <div class="col-sm-8 card-container padding-bottom-0 padding-top-0">
-        <div id="livestream" class="card-panel bordered panel panel-default match-height-item-by-row">
+        <div id="social-cards" class="card-panel bordered panel panel-default match-height-item-by-row">
             <img src="/images/icons/socialcards.svg" width="60" class="margin-bottom-15" alt="Social Cards">
             <h3 class="big-text text-secondary h4">{{ i18n "pages-resources-social-cards-title" }}</h3>
             <ul>

--- a/layouts/shortcodes/pages/resources.html
+++ b/layouts/shortcodes/pages/resources.html
@@ -64,7 +64,7 @@
             <img src="/images/icons/livestream.svg" width="60" class="margin-bottom-15" alt="JakartaOne Livestream">
             <h3 class="big-text text-secondary h4">{{ i18n "pages-resources-livestream-title" }}</h3>
             <ul>
-                <li><a href="#">{{ i18n "pages-resources-livestream-events" }}</a></li>
+                <li><a href="https://jakartaone.org/">{{ i18n "pages-resources-livestream-events" }}</a></li>
             </ul>
         </div>
     </div>


### PR DESCRIPTION
Resolves #1578 

It seems like the `href` was never set for this link. This PR fixes that.

Also, fixes a duplicate id of a resource card.