### PR TITLE
Fix meeting-minutes-single shortcode not rendering minutes

### DIFF
--- a/data/meeting_minutes.yml
+++ b/data/meeting_minutes.yml
@@ -1,3 +1,10 @@
+years:
+   - 2023
+   - 2022
+   - 2021
+   - 2020
+   - 2019
+   - 2018
 dir: /about/meeting_minutes/
 items:
    marketing_committee:

--- a/layouts/shortcodes/meeting-minutes-single.html
+++ b/layouts/shortcodes/meeting-minutes-single.html
@@ -7,7 +7,7 @@
     <h4>{{ $year }}</h4>
     <ul class="tri-col">
     {{ range $index, $el := (where $meeting_minute_types "year" $year) }}
-      <li><a href="{{absURL (printf "/meeting_minutes/%s" $el.url) }}">{{$el.title}}</a></li>
+      <li><a href="{{absURL (printf "/about/meeting_minutes/%s" $el.url) }}">{{$el.title}}</a></li>
     {{ end }}
     </ul>
     {{ end }}


### PR DESCRIPTION
Resolves #1634 

Bug fix

When upgrading the meeting_minutes shortcode into eclipsefdn_meeting_minutes, we removed the need to have the `years` field in data.yml. However, another shortcode named `meeting-minutes-single` was still reliant on this `years` field.