### PR TITLE
Hotfix button group buttons not having equal height

### DIFF
--- a/less/styles.less
+++ b/less/styles.less
@@ -295,3 +295,14 @@ div.card-panel.panel div.panel-body.panel-body-with-img {
   font-weight: 700;
   margin-top: 10px;
 }
+
+// Hotfixes
+.project-summary {
+  .btn-sm {
+    .btn;
+    
+    &:hover {
+      color: @white;
+    }
+  }
+}


### PR DESCRIPTION
Resolves #1588 

This is fixed in EFHST 0.0.183 but it also includes Hugo v110 and Node 18. We're not going to upgrade the Hugo and Node version here just yet.

In the meantime, I suggest we add this hotfix.