### PR TITLE
fix: Breadcrumbs missing

### DIFF
--- a/config/_default/config.toml
+++ b/config/_default/config.toml
@@ -10,6 +10,7 @@ enableRobotsTXT = true
 enableInlineShortcodes = true
 
 [Params]
+  layout_style = "quicksilver"
   google_tag_manager = "GTM-5WLCZXC"
   description = "Jakarta® Enterprise Edition (EE) is the future of cloud native Java. Jakarta® EE open source software drives cloud native innovation, modernizes enterprise applications and protects investments in Java EE."
   subtitle = "The New Home of Cloud Native Java"


### PR DESCRIPTION
Relates to #1717 

Breadcrumbs were missing from the site. This is because the breadcrumbs were using Astro's layout for some reason. Luckily, setting `layout_style` to `quicksilver` will fix this.

Ultimately, this seems to be a bug in EFHST. We shouldn't be using the Astro breadcrumbs by default.