### PR TITLE
feat: move content below spec list

### DIFF
--- a/layouts/specifications/list.html
+++ b/layouts/specifications/list.html
@@ -26,7 +26,6 @@
     </h1>
   {{ end }}
   <p>{{ .Params.summary }}</p>
-  {{ .Content }}
   {{ if eq .Page.Parent.Title "Specifications" }}
     <ul>
       {{ range (.Page.Sections.ByParam "title").ByParam "weight" }}
@@ -41,6 +40,7 @@
       {{ end }}
     </ul>
   {{ end }}
+  {{ .Content }}
   {{ if eq .Page.Parent.Title "Home" }}
     <p>{{ i18n "layouts-specifications-list-click-to-access-text" }}</p>
 


### PR DESCRIPTION
We are beginning to add content to the specification list pages. However, the content needs to appear below the specification list.