### PR TITLE
fix: broken images on multilingual learn page

### DIFF
--- a/layouts/shortcodes/pages/learn/index.html
+++ b/layouts/shortcodes/pages/learn/index.html
@@ -14,7 +14,7 @@
 
 <section class="column-section column-section-even gap-60">
   <div class="image-column hidden-xs hidden-sm">
-    <img src="./images/starter-guides.jpg" alt="" />
+    <img src="/learn/images/starter-guides.jpg" alt="" />
   </div>
   <div>
     <h2 class="big-text" id="starter-guides">Starter Guides</h2>
@@ -55,7 +55,7 @@
     <h2 class="big-text" id="Generate a Jakarta EE Project">Generate a Jakarta EE Project</h2>
     <div class="column-section column-section-even gap-40">
       <div class="image-column hidden-xs hidden-sm">
-        <img src="./images/generate-project.jpg" alt="" />
+        <img src="/learn/images/generate-project.jpg" alt="" />
       </div>
       <div>
         <p>
@@ -73,7 +73,7 @@
 
 <section class="column-section column-section-even gap-60">
   <div class="image-column">
-    <img src="./images/jakarta-ee-overview-course.jpg" alt="The thumbnail of Jakarta EE Overview Course found on Linkedin Learning." />
+    <img src="/learn/images/jakarta-ee-overview-course.jpg" alt="The thumbnail of Jakarta EE Overview Course found on Linkedin Learning." />
   </div>
   <div>
     <h2 class="big-text" id="jakarta-ee-essentials">Jakarta EE Overview Course</h2>


### PR DESCRIPTION
Using relative to root image urls instead of relative since the /zh/ part of the URL was unaccounted for.