### PR TITLE
issues/1813 Update TCK Process to unblock ballot release of EE 11 Specification ballots that have traditionally been done with Java SE style TCKs.

### DIFF
--- a/content/committees/specification/tckprocess/index.md
+++ b/content/committees/specification/tckprocess/index.md
@@ -51,11 +51,7 @@ There are 3 different types of TCKs, detailed below.
 - Type 2: Tests that only apply when running in a platform (or profile) to test behavior defined by the specification for that mode of execution.
 - Type 3: Tests that apply to the behavior defined by a specification for the execution either as a standalone or in a platform (or profile).
 
-The individual specification TCK must contain Type 2 or Type 3 tests while Type 1 tests are optional. A profile-ready mechanism must be provided for running the required TCK tests (types 2 and 3) in the profiles they are included in: platform, web profile or core profile. Type 1 tests must be excluded and not required to be executed.
-
-The individual specification TCK must provide a mechanism for running the required TCK tests (types 1 and 3) outside the context of a platform or profile. Type 2 tests must be excluded and not run.
-
-The type 3 tests must be executed in compatible implementations of the profiles to validate the individual specification implementation functions properly in the profile implementation: platform, web profile or core profile.
+A profile-ready mechanism must be provided for running the required TCK tests in the profiles they are included in: platform, web profile or core profile.
 
 ## Materials for a TCK Release {#_materials_for_a_tck_release}
 


### PR DESCRIPTION
See discussion on https://github.com/jakartaee/jakarta.ee/issues/1813.

If this change is made or a change like it, we should follow up to make a further change to cover `Update TCK Process to specify that Jakarta EE Platform implementations only need to pass TCK tests that can be run against a Platform (e.g. EE containers) implementation to be considered Jakarta EE Platform compatible.`  This change might not really belong in the TCK Process guide as it is specific to Platform/Profile TCKs.  I suggest that the https://github.com/jakartaee/platform-tck/tree/tckrefactor might be a better place to specify the requirement which does imply more work will be done for the Platform TCK to support running such tests (e.g. Core Profile 10 TCK already has an example of doing that).

CC @Emily-Jiang @lukasj 