### PR TITLE
fix: wrong specification project link

### DIFF
--- a/config/_default/menu.ja.toml
+++ b/config/_default/menu.ja.toml
@@ -205,7 +205,7 @@
 
 [[main]]
     name = "Specification Projects"
-    url = "https://projects.eclipse.org/list-of-projects?combine=jakarta&field_project_techology_types_tid=1102&field_state_value_2=All"
+    url = "/ja/projects/"
     weight = 4
     parent = "仕様"
 

--- a/config/_default/menu.toml
+++ b/config/_default/menu.toml
@@ -186,7 +186,7 @@
 
 [[main]]
     name = "Specification Projects"
-    url = "https://projects.eclipse.org/list-of-projects?combine=jakarta&field_project_techology_types_tid=1102&field_state_value_2=All"
+    url = "/projects/"
     weight = 4
     parent = "Specifications"
 

--- a/config/_default/menu.zh.toml
+++ b/config/_default/menu.zh.toml
@@ -203,7 +203,7 @@
 
 [[main]]
     name = "规范项目"
-    url = "https://projects.eclipse.org/list-of-projects?combine=jakarta&field_project_techology_types_tid=1102&field_state_value_2=All"
+    url = "/zh/projects/"
     weight = 4
     parent = "规范"
 


### PR DESCRIPTION
Resolves #1870 

Changes link from projects.eclipse.org to jakarta.ee's Jakarta EE projects list page.