### PR TITLE
fix: Various small fixes for the redesign

### DIFF
--- a/config/_default/config.toml
+++ b/config/_default/config.toml
@@ -8,6 +8,8 @@ googleAnalytics = "UA-910670-30"
 themesDir = "node_modules/"
 enableRobotsTXT = true
 enableInlineShortcodes = true
+## Suppress logging for now allowed raw HTML content
+ignoreLogs = ['warning-goldmark-raw-html']
 [markup.highlight]
   noClasses = false
   style = "github"

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -620,7 +620,7 @@ other = "Sign up now"
  other = "specifications"
 
 [jakarta-ee-version-9_1-previous-release-link]
- other = "<a id=\"text-white\" href=\"/release\" class=\"uppercase\">view all releases</a>"
+ other = "<a id=\"text-white\" href=\"/release\" class=\"uppercase vertical-align\">view all releases</a>"
 
 [jakarta-ee-version-9-section-skip-to-main-content]
  other = "Skip to main content"
@@ -638,7 +638,7 @@ other = "Sign up now"
  other = "specifications"
 
 [jakarta-ee-version-9-previous-release-link]
- other = "<a id=\"text-white\" href=\"/release\" class=\"uppercase\">view all releases</a>"
+ other = "<a id=\"text-white\" href=\"/release\" class=\"uppercase vertical-align\">view all releases</a>"
 
 [jakarta-ee-version-8-section-skip-to-main-content]
  other = "Skip to main content"

--- a/layouts/release/11/section.html
+++ b/layouts/release/11/section.html
@@ -36,7 +36,7 @@
                 </div>
               </div>
               <div class="additional-links">
-                <a class="uppercase" href="{{ relLangURL "/release" }}">View All Releases</a>
+                <a class="uppercase vertical-align" href="{{ relLangURL "/release" }}">View All Releases</a>
               </div>
             </div>
             <div class="col-md-13 col-md-offset-1 hidden-xs hidden-sm">

--- a/layouts/shortcodes/pages/community/videos.html
+++ b/layouts/shortcodes/pages/community/videos.html
@@ -17,7 +17,7 @@
                 <img src="/images/jakarta_ee_logo_stacked.svg" alt="Jakarta EE">
             </span>
         </div>
-        <div class="col-sm-12 match-height-item-by-row">
+        <div class="col-sm-14 match-height-item-by-row">
             <h2 class="big-text">Subscribe to our Youtube Channel</h2>
             <ul class="list-inline">
                 <li><i class="icon" data-feather="check"></i> Learn more about Jakarta</li>
@@ -25,7 +25,7 @@
                 <li><i class="icon" data-feather="check"></i> Webinars</li>
             </ul>
         </div>
-        <div class="col-sm-8 match-height-item-by-row vertical-align-container">
+        <div class="col-sm-6 match-height-item-by-row vertical-align-container">
             <p class="text-right margin-bottom-0"><a class="btn btn-secondary btn-lg" href="https://www.youtube.com/c/JakartaEE">Subscribe</a></p>
         </div>
     </div>

--- a/layouts/shortcodes/pages/release/11.html
+++ b/layouts/shortcodes/pages/release/11.html
@@ -166,14 +166,14 @@
             <img class="info-card-icon" src="./images/tutorial-icon.svg" alt="" />
           </div>
         </div>
-        <p class="info-card-heading big-text text-secondary">
+        <p class="info-card-heading big-text-secondary text-secondary">
           {{ i18n "jakarta-ee-version-11-info-card-tutorial-title" | safeHTML }}
         </p>
         <div class="info-card-body">
           {{ i18n "jakarta-ee-version-11-info-card-tutorial-description" | safeHTML }}
         </div>
         <div class="info-card-link-container">
-          <a class="info-card-link big-text text-secondary uppercase" href="{{ relURL "/learn/docs/jakartaee-tutorial/current/index.html" }}">
+          <a class="info-card-link big-text-secondary text-secondary uppercase" href="{{ relURL "/learn/docs/jakartaee-tutorial/current/index.html" }}">
             {{ i18n "read-more" }}
           </a>
         </div>
@@ -185,7 +185,7 @@
             <img class="info-card-icon" src="./images/starter-icon.svg" alt="" />
           </div>
         </div>
-        <p class="info-card-heading big-text text-secondary">
+        <p class="info-card-heading big-text-secondary text-secondary">
           {{ i18n "jakarta-ee-version-11-info-card-starter-guides-title" | safeHTML }}
         </p>
         <div class="info-card-body">
@@ -194,7 +194,7 @@
           </p>
         </div>
         <div class="info-card-link-container">
-          <a class="info-card-link big-text text-secondary uppercase" href="{{ relLangURL "/learn/starter-guides" }}">
+          <a class="info-card-link big-text-secondary text-secondary uppercase" href="{{ relLangURL "/learn/starter-guides" }}">
             {{ i18n "read-more" }}
           </a>
         </div>
@@ -206,7 +206,7 @@
             <img class="info-card-icon" src="./images/specification-icon.svg" alt="" />
           </div>
         </div>
-        <p class="info-card-heading big-text text-secondary">
+        <p class="info-card-heading big-text-secondary text-secondary">
           {{ i18n "jakarta-ee-version-11-info-card-specification-guides-title" | safeHTML }}
         </p>
         <div class="info-card-body">
@@ -215,7 +215,7 @@
           </p>
         </div>
         <div class="info-card-link-container">
-          <a class="info-card-link big-text text-secondary uppercase" href="{{ relLangURL "/learn/specification-guides" }}">
+          <a class="info-card-link big-text-secondary text-secondary uppercase" href="{{ relLangURL "/learn/specification-guides" }}">
             {{ i18n "browse-now" }}
           </a>
         </div>
@@ -227,7 +227,7 @@
             <img class="info-card-icon" src="./images/learn-icon.svg" alt="" style="padding: 0.5rem;" />
           </div>
         </div>
-        <p class="info-card-heading big-text text-secondary">
+        <p class="info-card-heading big-text-secondary text-secondary">
           {{ i18n "jakarta-ee-version-11-info-card-learn-title" | safeHTML }}
         </p>
         <div class="info-card-body">
@@ -236,7 +236,7 @@
           </p>
         </div>
         <div class="info-card-link-container">
-          <a class="info-card-link big-text text-secondary uppercase" href="{{ relLangURL "/learn/" }}">
+          <a class="info-card-link big-text-secondary text-secondary uppercase" href="{{ relLangURL "/learn/" }}">
             {{ i18n "read-more" }}
           </a>
         </div>

--- a/less/components/_buttons.less
+++ b/less/components/_buttons.less
@@ -50,6 +50,7 @@
   font-size: @btn-font-size;
   padding: 0.5rem 2rem;
   transition: transform 0.2s cubic-bezier(0.39, -0.35, 0.54, 2.04);
+  text-wrap: auto;
 
   &:active {
     transform: scale(0.95);

--- a/less/components/typography.less
+++ b/less/components/typography.less
@@ -24,9 +24,6 @@
 
 .text-secondary {
     color: @brand-primary-orange;
-    &:hover {
-        color: @brand-primary-orange;
-    }
     a {
         color: @brand-primary-orange;
         &:hover {
@@ -93,6 +90,7 @@ h6, .h6 {
 
 .big-text, .big-text-secondary {
     .featured-text;
+    .text-semibold;
     color: @brand-primary;
     a {
         color: @brand-primary;

--- a/less/featured_content.less
+++ b/less/featured_content.less
@@ -37,11 +37,7 @@
   }
   
   .featured-footer, .featured-story {
-    &.featured-alternate {
-      & {
-        background-color: #000;
-      }
-    }
+    background-color: #000;
 
     &.featured-story-light {
       background-position: center;

--- a/less/release-11.less
+++ b/less/release-11.less
@@ -1,4 +1,5 @@
 .header-release-11 {
+  font-family: Open Sans; // required to retain spacing + look and feel of header
   video {
     position: absolute;
     min-width: 100%;


### PR DESCRIPTION
Includes fixes for:

- /release/11/; Jumbotron styling, bottom of page tile text colour not aligning
- /release/9/; Fix all releases anchor alignment to feel more natural
- /community/videos/; Fix banner to flow better at most breakpoints
- General fixes; Add text wrap to btn class, remove hover effect on non-anchor secondary text, add black background behind image for featured banners