### PR TITLE
fix: Fix non-rendering v11 release page, fix button style

### DIFF
--- a/layouts/release/11/section.html
+++ b/layouts/release/11/section.html
@@ -1,14 +1,3 @@
-<!--
- Copyright (c) 2025 Eclipse Foundation AISBL
-
- This program and the accompanying materials are made
- available under the terms of the Eclipse Public License 2.0
- which is available at https://www.eclipse.org/legal/epl-2.0/
-
- SPDX-License-Identifier: EPL-2.0
--->
-
-
 {{ define "header"}}
   <a class="sr-only" href="#content">{{ i18n "jakarta-ee-version-10-section-skip-to-main-content" }}</a>
   {{ partial "toolbar.html" . }}

--- a/less/release-11.less
+++ b/less/release-11.less
@@ -79,6 +79,7 @@
       display: block;
       width: 100%;
       padding: 1rem;
+      border-color: white;
     }
 
     @media (min-width: @screen-md-min) {


### PR DESCRIPTION
/release/11 page was fully broken from rendering. This was caused by the comment section which seems to clobber the whole rendered file.