### PR TITLE
feat(committees): sync marketing committee zh and ja with en

### DIFF
--- a/content/committees/marketing/_index.ja.md
+++ b/content/committees/marketing/_index.ja.md
@@ -10,9 +10,9 @@ date: 2020-01-05T15:50:25-04:00
 ### 委員会メンバー
 
 * Kenji Kazumura - 富士通、Yuichi Kusano - 代理
-* Neil Patterson (**委員長**) - IBM
+* Neil Patterson - IBM, Emily Jiang - 代理
 * Ed Bratt - Oracle、Melissa Jacobus - 代理
-* Dominika Tasarz - Payara、Jadon Ortlepp - 代理
+* Dominika Tasarz (**委員長**) - Payara、Jadon Ortlepp - 代理
 * Jonathan Gallimore - Tomitribe、Cesar Hernandez - 代理
 * Eric (QingYu) Meng - Primeton - 選出されたEnterpriseメンバー代表
 * Sonja Gu - Microsoft - 選出されたEnterpriseメンバー代表

--- a/content/committees/marketing/_index.zh.md
+++ b/content/committees/marketing/_index.zh.md
@@ -10,9 +10,9 @@ date: 2020-01-05T15:50:25-04:00
 ### 委员会成员
 
 * Kenji Kazumura - Fujitsu, Yuichi Kusano - alternate
-* Neil Patterson (**chair**) - IBM
+* Neil Patterson - IBM, Emily Jiang - alternate
 * Ed Bratt - Oracle, Melissa Jacobus - alternate
-* Dominika Tasarz - Payara, Jadon Ortlepp - alternate
+* Dominika Tasarz (**chair**) - Payara, Jadon Ortlepp - alternate
 * Jonathan Gallimore - Tomitribe, Cesar Hernandez - alternate
 * Eric (QingYu) Meng - Primeton - Elected Enterprise Representative
 * Sonja Gu - Microsoft - Elected Enterprise Representative


### PR DESCRIPTION
We made an update to the marketing committee for English pages but we didn't add the changes to ZH and JA