### PR TITLE
Update conference entries in conferences_ivar.yml

### DIFF
--- a/data/conferences_ivar.yml
+++ b/data/conferences_ivar.yml
@@ -77,19 +77,17 @@ years:
     url: https://zenlipa.co.ke/events/js61T1
     location: Nairobi 🇰🇪
     date: May 9
-    upcoming: true
 
   - name: University of York (Guest Lecture)
     url: https://www.york.ac.uk
     location: York 🏴󠁧󠁢󠁥󠁮󠁧󠁿
     date: May 5
-    upcoming: true
 
   - name: ShiftAPPens
     url: https://www.shiftappens.com
     location: Coimbra 🇵🇹
     date: May 1-3
-    upcoming: true
+    blog: https://www.agilejava.eu/2026/05/11/shiftappens-2026/
 
   - name: Open Community eXperience
     url: https://www.ocxconf.org


### PR DESCRIPTION
Removed 'upcoming' field from several conference entries and added a blog link for ShiftAPPens.